### PR TITLE
fix: adds selectorPrefix to animationName

### DIFF
--- a/packages/fela/src/createRenderer.js
+++ b/packages/fela/src/createRenderer.js
@@ -89,9 +89,9 @@ export default function createRenderer(
 
       if (!renderer.cache.hasOwnProperty(keyframeReference)) {
         // use another unique identifier to ensure minimal css markup
-        const animationName = generateAnimationName(
-          ++renderer.uniqueKeyframeIdentifier
-        )
+        const animationName =
+          renderer.selectorPrefix +
+          generateAnimationName(++renderer.uniqueKeyframeIdentifier)
 
         const cssKeyframe = cssifyKeyframe(
           processedKeyframe,
@@ -234,8 +234,8 @@ export default function createRenderer(
               combinedSupport
             )
           } else {
-            console.warn(`The object key "${property}" is not a valid nested key in Fela. 
-Maybe you forgot to add a plugin to resolve it? 
+            console.warn(`The object key "${property}" is not a valid nested key in Fela.
+Maybe you forgot to add a plugin to resolve it?
 Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information.`)
           }
         } else {


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->
https://github.com/rofrischmann/fela/issues/713
## Description
According to the documentation, `selectorPrefix` should work with keyframes.
> Prepend a static prefix to every generated class and **keyframe**. It must only consist of a-zA-Z0-9-_ and start with a-zA-Z_.

I made a more complex solution [here](https://github.com/rofrischmann/fela/pull/715) that adds `animationPrefix` as a configuration key but we can totally reuse the `selectorPrefix` as the docs originally state

## Packages
fela

- 

## Versioning
Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

