### PR TITLE
Remove deprecated mountNode usages

### DIFF
--- a/docs/api/fela-native/Renderer.md
+++ b/docs/api/fela-native/Renderer.md
@@ -26,7 +26,7 @@ Renders a `rule` using the `props` to resolve it.
 ```javascript
 import { createRenderer } from 'fela'
 
-const renderer = createRenderer(mountNode)
+const renderer = createRenderer()
 
 const rule = props => ({
   backgroundColor: 'red',
@@ -105,7 +105,7 @@ Adds a change `listener` to get notified when changes happen.
 ```javascript
 import { createRenderer } from 'fela'
 
-const renderer = createRenderer(mountNode)
+const renderer = createRenderer()
 
 const rule = props => ({
   fontSize: props.fontSize,

--- a/docs/api/fela/Renderer.md
+++ b/docs/api/fela/Renderer.md
@@ -29,7 +29,7 @@ Renders a `rule` using the `props` to resolve it.
 ```javascript
 import { createRenderer } from 'fela'
 
-const renderer = createRenderer(mountNode)
+const renderer = createRenderer()
 
 const rule = props => ({
   backgroundColor: 'red',
@@ -107,7 +107,7 @@ Renders a `keyframe` using the `props` to resolve it.
 ```javascript
 import { createRenderer } from 'fela'
 
-const renderer = createRenderer(mountNode)
+const renderer = createRenderer()
 
 const keyframe = props => ({
   '0%': { color: props.initialColor },
@@ -143,7 +143,7 @@ Renders a `@font-face` rule using the `family` as reference.
 ```javascript
 import { createRenderer } from 'fela'
 
-const renderer = createRenderer(mountNode)
+const renderer = createRenderer()
 
 const files = [
   '../fonts/Lato.ttf',
@@ -172,7 +172,7 @@ Renders static styles.
 ```javascript
 import { createRenderer } from 'fela'
 
-const renderer = createRenderer(mountNode)
+const renderer = createRenderer()
 
 // string type style
 renderer.renderStatic('html,body{box-sizing:border-box;margin:0}').
@@ -194,7 +194,7 @@ You can even reuse existing formatted CSS using [ECMAScript 2015](http://www.ecm
 ```javascript
 import { createRenderer } from 'fela'
 
-const renderer = createRenderer(mountNode)
+const renderer = createRenderer()
 
 renderer.renderStatic(`
 html, body {
@@ -228,7 +228,7 @@ Adds a change `listener` to get notified when changes happen.
 ```javascript
 import { createRenderer } from 'fela'
 
-const renderer = createRenderer(mountNode)
+const renderer = createRenderer()
 
 const rule = props => ({
   fontSize: props.fontSize,

--- a/docs/api/fela/combineRules.md
+++ b/docs/api/fela/combineRules.md
@@ -15,7 +15,7 @@ Accepts a list of [Rules](../../advanced/Rules.md).
 ```javascript
 import { combineRules } from 'fela'
 
-const renderer = createRenderer(mountNode)
+const renderer = createRenderer()
 
 const rule = props => ({
   fontSize: props.fontSize

--- a/packages/react-fela/index.d.ts
+++ b/packages/react-fela/index.d.ts
@@ -31,7 +31,6 @@ declare module "react-fela" {
 
   interface ProviderProps {
     renderer: object;
-    mountNode?: any;
   }
 
   interface FelaWithThemeProps<Theme> {


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
Remove deprecated mountNode usages from documentation examples and TypeScript typings.  The prop seems to have been removed in #156

## Example
```javascript
createRenderer(mountNode)
```

## Packages
List all packages that have been changed.

- react-fela

## Versioning
None / Patch / Minor / Major

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [ ✔️ ] The code was formatted using Prettier (`yarn run format`)
- [ ✔️ ] The code has no linting errors (`yarn run lint`)
- [ ✔️ ] All tests are passing (`yarn run test`) 
- [ ✔️ ] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [ ✔️ ] Tests have been added/updated
- [ ✔️ ] Documentation has been added/updated
- [ ✔️ ] My changes have proper flow-types

