### PR TITLE
feat(RendererProvider): add `target` prop

### DIFF
--- a/flowtypes/DOMRenderer.js
+++ b/flowtypes/DOMRenderer.js
@@ -1,5 +1,11 @@
 import type Cache from './Cache'
 
+export type DOMRendererDocumentRef = {
+  target: Document,
+  refId: string,
+  refCount: number,
+}
+
 export type DOMRenderer = {
   keyframePrefixes: Array<string>,
   plugins: Array<Function>,
@@ -10,12 +16,14 @@ export type DOMRenderer = {
   uniqueRuleIdentifier: number,
   uniqueKeyframeIdentifier: number,
   cache: Cache,
-  nodes: Object,
+  documentRefs: Array<DOMRendererDocumentRef>,
+  nodes: { [string]: { node: Object, refId: string, score: string } },
   renderRule: Function,
   renderKeyframe: Function,
   renderStatic: Function,
   renderFont: Function,
   subscribe: Function,
+  subscribeDocument: Function,
   clear: Function,
   _renderStyleToClassNames: Function,
   _emitChange: Function,

--- a/packages/fela-bindings/src/RendererProviderFactory.js
+++ b/packages/fela-bindings/src/RendererProviderFactory.js
@@ -28,11 +28,21 @@ export default function RendererProviderFactory(
       super(props, context)
 
       if (hasDOM(props.renderer)) {
+        if (props.target) {
+          this.subscription = props.renderer.subscribeDocument(props.target)
+        }
+
         if (props.rehydrate && hasServerRenderedStyle()) {
           rehydrate(props.renderer)
         } else {
           render(props.renderer)
         }
+      }
+    }
+
+    componentWillUnmount() {
+      if (hasDOM(this.props.renderer) && this.subscription) {
+        this.subscription.unsubscribe()
       }
     }
 

--- a/packages/fela-dom/src/dom/connection/__tests__/createNode-test.js
+++ b/packages/fela-dom/src/dom/connection/__tests__/createNode-test.js
@@ -17,7 +17,12 @@ describe('Creating a style node', () => {
     const getHTML = (media, support) => ({
       _media: media,
       _support: support,
-      html: createNode({}, 0, { type: RULE_TYPE, media, support }).outerHTML,
+      html: createNode(
+        {},
+        0,
+        { type: RULE_TYPE, media, support },
+        { target: document }
+      ).outerHTML,
     })
 
     expect(getHTML()).toMatchSnapshot()
@@ -30,7 +35,7 @@ describe('Creating a style node', () => {
     const nodes = {}
 
     function createAndAdd(score, attributes) {
-      const node = createNode(nodes, score, attributes)
+      const node = createNode(nodes, score, attributes, { target: document })
       nodes[JSON.stringify(attributes) + score] = { node, score }
     }
 

--- a/packages/fela-dom/src/dom/connection/__tests__/queryNode-test.js
+++ b/packages/fela-dom/src/dom/connection/__tests__/queryNode-test.js
@@ -10,7 +10,9 @@ it('should not query nodes with media attributes if media is not defined', () =>
 
   document.head.innerHTML = nodeInvalid + nodeValid
 
-  expect(queryNode({ type: RULE_TYPE }).outerHTML).toBe(nodeValid)
+  expect(queryNode({ type: RULE_TYPE }, { target: document }).outerHTML).toBe(
+    nodeValid
+  )
 })
 
 it('should not query nodes with support attributes if support is not defined', () => {
@@ -21,5 +23,7 @@ it('should not query nodes with support attributes if support is not defined', (
 
   document.head.innerHTML = nodeInvalid + nodeValid
 
-  expect(queryNode({ type: RULE_TYPE }).outerHTML).toBe(nodeValid)
+  expect(queryNode({ type: RULE_TYPE }, { target: document }).outerHTML).toBe(
+    nodeValid
+  )
 })

--- a/packages/fela-dom/src/dom/connection/createNode.js
+++ b/packages/fela-dom/src/dom/connection/createNode.js
@@ -2,13 +2,15 @@
 import objectReduce from 'fast-loops/lib/objectReduce'
 
 import type { NodeAttributes } from '../../../../../flowtypes/DOMNode'
+import type { DOMRendererDocumentRef } from '../../../../../flowtypes/DOMRenderer'
 
 export default function createNode(
   nodes: Object,
   score: number,
-  { type, media, support }: NodeAttributes
+  { type, media, support }: NodeAttributes,
+  documentRef: DOMRendererDocumentRef
 ): Object {
-  const head = document.head || {}
+  const head = documentRef.target.head || {}
 
   const node = document.createElement('style')
   node.setAttribute('data-fela-type', type)
@@ -27,6 +29,7 @@ export default function createNode(
   const moreSpecificReference = objectReduce(
     nodes,
     (closest, currentNode, reference) =>
+      currentNode.refId === documentRef.refId &&
       currentNode.score > score &&
       (!closest || nodes[closest].score > currentNode.score)
         ? reference

--- a/packages/fela-dom/src/dom/connection/createSubscription.js
+++ b/packages/fela-dom/src/dom/connection/createSubscription.js
@@ -1,5 +1,6 @@
 /* @flow */
 /* eslint-disable consistent-return */
+import arrayEach from 'fast-loops/lib/arrayEach'
 import objectEach from 'fast-loops/lib/objectEach'
 import {
   RULE_TYPE,
@@ -27,26 +28,28 @@ export default function createSubscription(renderer: DOMRenderer): Function {
       return
     }
 
-    const node = getNodeFromCache(change, renderer)
+    arrayEach(renderer.documentRefs, documentRef => {
+      const node = getNodeFromCache(change, renderer, documentRef)
 
-    switch (change.type) {
-      case KEYFRAME_TYPE:
-        node.textContent += change.keyframe
-        break
-      case FONT_TYPE:
-        node.textContent += change.fontFace
-        break
-      case STATIC_TYPE:
-        node.textContent += change.selector
-          ? generateCSSRule(change.selector, change.css)
-          : change.css
-        break
-      case RULE_TYPE:
-        insertRule(change, renderer, node)
-        break
-      default:
-        // TODO: warning
-        break
-    }
+      switch (change.type) {
+        case KEYFRAME_TYPE:
+          node.textContent += change.keyframe
+          break
+        case FONT_TYPE:
+          node.textContent += change.fontFace
+          break
+        case STATIC_TYPE:
+          node.textContent += change.selector
+            ? generateCSSRule(change.selector, change.css)
+            : change.css
+          break
+        case RULE_TYPE:
+          insertRule(change, renderer, node, documentRef)
+          break
+        default:
+          // TODO: warning
+          break
+      }
+    })
   }
 }

--- a/packages/fela-dom/src/dom/connection/getNodeFromCache.js
+++ b/packages/fela-dom/src/dom/connection/getNodeFromCache.js
@@ -3,29 +3,34 @@ import calculateNodeScore from './calculateNodeScore'
 import queryNode from './queryNode'
 import createNode from './createNode'
 
-import type { DOMRenderer } from '../../../../../flowtypes/DOMRenderer'
+import type {
+  DOMRenderer,
+  DOMRendererDocumentRef,
+} from '../../../../../flowtypes/DOMRenderer'
 import type { NodeAttributes } from '../../../../../flowtypes/DOMNode'
 
-function getReference({
-  type,
-  media = '',
-  support = '',
-}: NodeAttributes): string {
-  return type + media + support
+function getReference(
+  { type, media = '', support = '' }: NodeAttributes,
+  documentRef: DOMRendererDocumentRef
+): string {
+  return type + media + support + documentRef.refId
 }
 
 export default function getNodeFromCache(
   attributes: NodeAttributes,
-  renderer: DOMRenderer
+  renderer: DOMRenderer,
+  documentRef: DOMRendererDocumentRef
 ): Object {
-  const reference = getReference(attributes)
+  const reference = getReference(attributes, documentRef)
 
   if (!renderer.nodes[reference]) {
     const score = calculateNodeScore(attributes, renderer.mediaQueryOrder)
     const node =
-      queryNode(attributes) || createNode(renderer.nodes, score, attributes)
+      queryNode(attributes, documentRef) ||
+      createNode(renderer.nodes, score, attributes, documentRef)
 
     renderer.nodes[reference] = {
+      refId: documentRef.refId,
       node,
       score,
     }

--- a/packages/fela-dom/src/dom/connection/insertRule.js
+++ b/packages/fela-dom/src/dom/connection/insertRule.js
@@ -7,14 +7,18 @@ import {
 
 import insertRuleInDevMode from './insertRuleInDevMode'
 
-import type { DOMRenderer } from '../../../../../flowtypes/DOMRenderer'
+import type {
+  DOMRenderer,
+  DOMRendererDocumentRef,
+} from '../../../../../flowtypes/DOMRenderer'
 
 export default function insertRule(
   { selector, declaration, support, media, pseudo }: Object,
   renderer: DOMRenderer,
-  node: Object
+  node: Object,
+  documentRef: DOMRendererDocumentRef
 ) {
-  const nodeReference = media + support
+  const nodeReference = media + support + documentRef.refId
   // only use insertRule in production as browser devtools might have
   // weird behavior if used together with insertRule at runtime
   if (renderer.devMode) {

--- a/packages/fela-dom/src/dom/connection/queryNode.js
+++ b/packages/fela-dom/src/dom/connection/queryNode.js
@@ -1,16 +1,17 @@
 /* @flow */
 import type { NodeAttributes } from '../../../../../flowtypes/DOMNode'
+import type { DOMRendererDocumentRef } from '../../../../../flowtypes/DOMRenderer'
 
 export default function queryNode(
   { type, media, support }: NodeAttributes,
-  id?: string = ''
+  documentRef: DOMRendererDocumentRef
 ): ?Object {
   const mediaQuery = media ? `[media="${media}"]` : ':not([media])'
   const supportQuery = support
     ? '[data-fela-support="true"]'
     : ':not([data-fela-support="true"])'
 
-  return document.querySelector(
+  return documentRef.target.querySelector(
     `[data-fela-type="${type}"]${supportQuery}${mediaQuery}`
   )
 }

--- a/packages/fela/README.md
+++ b/packages/fela/README.md
@@ -211,6 +211,7 @@ Don't want to miss any update? Follow us on [Twitter](https://twitter.com/felajs
 - [Kilix](http://kilix.fr)
 - [Lusk](https://lusk.io)
 - [MediaFire](https://m.mediafire.com)
+- [Microsoft](https://microsoft.com)
 - [N26](https://n26.com)
 - [Net-A-Porter](https://www.net-a-porter.com/gb/en/porter)
 - [NinjaConcept](https://www.ninjaconcept.com)

--- a/packages/fela/src/getDocumentRefIndex.js
+++ b/packages/fela/src/getDocumentRefIndex.js
@@ -1,0 +1,17 @@
+import arrayReduce from 'fast-loops/lib/arrayReduce'
+
+import type { DOMRendererDocumentRef } from '../../../flowtypes/DOMRenderer'
+
+const getDocumentRefIndex = (
+  documentRefs: DOMRendererDocumentRef[],
+  target: Object
+) =>
+  arrayReduce(documentRefs, (accIndex, documentRef, index) => {
+    if (documentRef.target === target) {
+      return index
+    }
+
+    return accIndex
+  })
+
+export default getDocumentRefIndex

--- a/packages/react-fela/index.d.ts
+++ b/packages/react-fela/index.d.ts
@@ -31,6 +31,7 @@ declare module "react-fela" {
 
   interface ProviderProps {
     renderer: object;
+    target?: Document;
     mountNode?: any;
   }
 


### PR DESCRIPTION
## Description

Another approach (from #704) for fixing #693.

### `RendererProvider`

Now this component accepts `target` prop like in `styles-components` [StyleSheetManager.js#L25](https://github.com/styled-components/styled-components/blob/v4.3.1/packages/styled-components/src/models/StyleSheetManager.js#L25), it allows to specify a `Document` where style nodes will be attached.

### `subscribeDocument()` & `documentRefs`

This method is added to handle cases with passed documents, this implementation allows us to have a single subscription (difference from #704). `subscribeDocument()` returns and object with `unsubscribe()` like `subscribe()` does.

```js
const r = createRenderer()

r.subscribeDocument(childDocument)
felaDOM.render(r)
// styles will be renderer to main `document` and `childDocument`
```

However, we need to store `Document` object somewhere, I propose:

```js
{
  target: Document
  refId: string
  refCount: number
}
```

We need to have `refCount` to know when we should remove matching `Document` and clear `renderer.nodes` to avoid memory leaks. `refId` is used by build `reference` key in `renderer.nodes` because we can't rely on indexes.

## TODO

- [ ] update docs
- [ ] add unit tests

## Example

```jsx
<RendererProvider target={childDocument} />
```

## Packages
List all packages that have been changed.

- `fela-bindings`
- `fela-dom`
- `fela`
- `react-fela`

## Versioning
Minor

## Checklist

#### Quality Assurance

- [ ] The code was formatted using Prettier (`yarn run format`)
- [ ] The code has no linting errors (`yarn run lint`)
- [ ] All tests are passing (`yarn run test`) 
- [ ] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [ ] Tests have been added/updated
- [ ] Documentation has been added/updated
- [ ] My changes have proper flow-types

